### PR TITLE
Fix subtitle download to work across cross-device boundaries

### DIFF
--- a/subtitle-downloader.py
+++ b/subtitle-downloader.py
@@ -13,6 +13,7 @@
 # TODO: use another DB if subs are not found on subDB
 import hashlib
 import os
+import shutil 
 import sys
 import logging
 import requests,time,re,zipfile
@@ -94,7 +95,7 @@ def sub_downloader2(file_path):
                 zip.extractall(root2)
                 zip.close()
                 os.unlink(root2+".zip")
-                os.rename(root2+zip.namelist()[0], os.path.join(root2, root + ".srt"))
+                shutil.move(root2+zip.namelist()[0], os.path.join(root2, root + ".srt"))
     except:
         #Ignore exception and continue
         print("Error in fetching subtitle for " + file_path)


### PR DESCRIPTION
When I tried to run the subtitle downloader on a video file located in my SD card connected via USB I got the following error

```
$ python subtitle-downloader.py /Volumes/Untitled/4.mp4
Error in fetching subtitle for /Volumes/Untitled/4.mp4
('Error', (<type 'exceptions.OSError'>, OSError(18, 'Cross-device link'), <traceback object at 0x1068e
eb48>))
```

Seems like `os.rename()` doesn't work well across device boundaries. But changing it to `shutil.move()` fixes the issue.