### PR TITLE
Added requirements.txt File

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+beautifulsoup4==4.6.0
+bs4==0.0.1
+certifi==2017.4.17
+chardet==3.0.3
+idna==2.5
+requests==2.17.3
+urllib3==1.21.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ bs4==0.0.1
 certifi==2017.4.17
 chardet==3.0.3
 idna==2.5
+lxml==3.8.0
 requests==2.17.3
 urllib3==1.21.1


### PR DESCRIPTION
Fix #41 
Thus user can use the command pip freeze -r requirement.txt to install the dependency required to run the script.   