### PR TITLE
Renamed zip to zip_ (Following PEP 8 conventions)

### DIFF
--- a/subtitle-downloader.py
+++ b/subtitle-downloader.py
@@ -92,9 +92,9 @@ def sub_downloader2(file_path):
                 subfile.write(chunk)
                 subfile.close()
                 time.sleep(1)
-                zip=zipfile.ZipFile(root2+".zip")
-                zip.extractall(root2)
-                zip.close()
+                zip_=zipfile.ZipFile(root2+".zip") #Naming zip is not recommended renamed it to zip_ (Following PEP 8 convention)
+                zip_.extractall(root2)             #Naming it as zip would overwrite built-in function zip
+                zip_.close()
                 os.unlink(root2+".zip")
                 shutil.move(root2+zip.namelist()[0], os.path.join(root2, root + ".srt"))
     except:


### PR DESCRIPTION
Naming  `zip = zipfile.ZipFile(root2+".zip")` would overwrite the built-in function **`zip()`**.
Renamed it to `zip_`.  Also great script kudos :)